### PR TITLE
feat: UserRegister 기능 추가 및 관련 유틸리티 구현

### DIFF
--- a/src/main/kotlin/com/dsm/hhh/external/security/PasswordEncoderUtils.kt
+++ b/src/main/kotlin/com/dsm/hhh/external/security/PasswordEncoderUtils.kt
@@ -1,0 +1,38 @@
+package com.dsm.hhh.external.security
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+
+/**
+ * PasswordEncoderUtil - 비밀번호 인코딩 유틸리티
+ * <p>
+ * 비밀번호 해싱을 위한 순수 유틸리티 클래스로, 스프링 빈으로 관리되지 않습니다.
+ * BCrypt 알고리즘을 사용한 비밀번호 인코딩/매칭 기능을 제공합니다.
+ * </p>
+ */
+object PasswordEncoderUtils {
+
+    private val encoder = BCryptPasswordEncoder()
+
+    /**
+     * 비밀번호를 BCrypt로 해싱합니다.
+     * @param rawPassword 원본 비밀번호
+     * @return 해시된 비밀번호
+     */
+    fun encode(rawPassword: String): String {
+        return encoder.encode(rawPassword)
+    }
+
+    /**
+     * 원본 비밀번호와 해시된 비밀번호가 일치하는지 검증합니다.
+     * @param rawPassword 검증할 원본 비밀번호
+     * @param encodedPassword 저장된 해시된 비밀번호
+     * @return 일치 여부
+     */
+    fun matches(
+        rawPassword: String,
+        encodedPassword: String
+    ): Boolean {
+        return encoder.matches(rawPassword, encodedPassword)
+    }
+
+}

--- a/src/main/kotlin/com/dsm/hhh/external/web/rest/auth/UserRegisterRestController.kt
+++ b/src/main/kotlin/com/dsm/hhh/external/web/rest/auth/UserRegisterRestController.kt
@@ -1,0 +1,58 @@
+package com.dsm.hhh.external.web.rest.auth
+
+import com.dsm.hhh.external.web.rest.auth.form.UserRegisterRequestForm
+import com.dsm.hhh.external.web.rest.auth.mapper.UserRegisterMapper
+import com.dsm.hhh.internal.core.domain.model.primitive.user.Name
+import com.dsm.hhh.internal.core.usecase.UserRegisterUseCase
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import reactor.core.publisher.Mono
+
+/**
+ * UserRegisterRestController - 사용자 회원가입 API 컨트롤러
+ * <p>
+ * 클라이언트로부터 회원가입 요청을 받아 처리하는 REST 컨트롤러입니다.
+ * Project Reactor 기반의 비동기 처리를 지원하며, 성공 시 HTTP 201(Created) 상태 코드를 반환합니다.
+ * </p>
+ *
+ * <p>
+ * 주요 역할:
+ * - 회원가입 요청 데이터 검증 (Form 객체 수준)
+ * - DTO 변환을 통해 내부 계층과 통신
+ * - 적절한 HTTP 상태 코드 반환
+ * </p>
+ *
+ * @author Kim Seung Won
+ * @since 2025-03-22
+ * @version 1.0
+ */
+@RestController
+@RequestMapping("/api/auth")
+class UserRegisterRestController(
+    private val userRegisterUseCase: UserRegisterUseCase
+) {
+
+    /**
+     * 사용자 회원가입 API 엔드포인트
+     * @param requestForm 회원가입 요청 데이터
+     * @return Mono<Void> - 처리 완료 시그널 (내용 없음)
+     *
+     * @HTTP 201 - 회원가입 성공
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun register(@RequestBody requestForm: UserRegisterRequestForm): Mono<Void> {
+        val userInternalDTO = UserRegisterMapper.toInternalDTO(requestForm)
+
+        return userRegisterUseCase.register(userInternalDTO)
+    }
+
+}
+
+data class Test(
+    val name: Name
+)

--- a/src/main/kotlin/com/dsm/hhh/external/web/rest/auth/form/UserRegisterRequestForm.kt
+++ b/src/main/kotlin/com/dsm/hhh/external/web/rest/auth/form/UserRegisterRequestForm.kt
@@ -1,0 +1,38 @@
+package com.dsm.hhh.external.web.rest.auth.form
+
+import com.dsm.hhh.internal.core.domain.model.primitive.user.Birthday
+import com.dsm.hhh.internal.core.domain.model.primitive.user.BreakupDate
+import com.dsm.hhh.internal.core.domain.model.primitive.user.Email
+import com.dsm.hhh.internal.core.domain.model.primitive.user.EmotionStatus
+import com.dsm.hhh.internal.core.domain.model.primitive.user.Name
+import com.dsm.hhh.internal.core.domain.model.primitive.user.Password
+
+/**
+ * UserRegisterRequestForm - 사용자 회원가입 요청 양식
+ * <p>
+ *
+ * @property email 사용자 이메일 주소
+ * @property password 비밀번호
+ * @property name 사용자 실명
+ * @property birthday 사용자 생년월일
+ * @property breakupDate 마지막 이별일
+ * @property emotionStatus 사용자 가입일의 감정 상태 (단위: %).
+ *
+ * <p>
+ *
+ * @author Kim Seung Won
+ * @since 2025-03-22
+ * @version 1.0
+ */
+class UserRegisterRequestForm(
+    val name: Name,
+    val email: Email,
+    val password: Password,
+
+    val birthday: Birthday,
+
+    val breakupDate: BreakupDate,
+    val emotionStatus: EmotionStatus
+) {
+
+}

--- a/src/main/kotlin/com/dsm/hhh/external/web/rest/auth/mapper/UserRegisterMapper.kt
+++ b/src/main/kotlin/com/dsm/hhh/external/web/rest/auth/mapper/UserRegisterMapper.kt
@@ -1,0 +1,47 @@
+package com.dsm.hhh.external.web.rest.auth.mapper
+
+import com.dsm.hhh.external.web.rest.auth.form.UserRegisterRequestForm
+import com.dsm.hhh.internal.core.domain.model.dto.user.UserInternalDTO
+import com.dsm.hhh.internal.core.domain.model.primitive.user.HashedPassword
+
+/**
+ * UserRegisterMapper - 회원가입 데이터 변환 매퍼
+ * <p>
+ * 웹 계층의 회원가입 요청 폼(UserRegisterRequestForm)을
+ * 도메인 계층에서 사용하는 DTO(UserInternalDTO)로 변환하는 매퍼 클래스입니다.
+ * 컴패니언 객체로 구현되어 인스턴스 생성 없이 사용 가능합니다.
+ * </p>
+ *
+ * <p>
+ * 변환 규칙:
+ * - 요청 폼의 필드들을 내부 DTO의 해당 필드들로 1:1 매핑
+ * - 필드 검증은 DTO 생성자에서 수행
+ * </p>
+ *
+ * @author Kim Seung Won
+ * @since 2025-03-22
+ * @version 1.0
+ */
+class UserRegisterMapper {
+
+    companion object {
+
+        /**
+         * 회원가입 요청 폼을 내부 DTO로 변환
+         * @param form 클라이언트로부터 받은 회원가입 요청 데이터
+         * @return 도메인 계층에서 사용할 UserInternalDTO
+         */
+        fun toInternalDTO(form: UserRegisterRequestForm): UserInternalDTO {
+            return UserInternalDTO(
+                name = form.name,
+                email = form.email,
+                password = HashedPassword.fromPassword(form.password),
+                birthday = form.birthday,
+                breakupDate = form.breakupDate,
+                emotionStatus = form.emotionStatus
+            )
+        }
+
+    }
+
+}

--- a/src/main/kotlin/com/dsm/hhh/internal/common/assertion/AssertionUtils.kt
+++ b/src/main/kotlin/com/dsm/hhh/internal/common/assertion/AssertionUtils.kt
@@ -1,0 +1,102 @@
+package com.dsm.hhh.internal.common.assertion
+
+/**
+ * AssertionUtils - 도메인 유효성 검증 유틸리티 클래스
+ * <p>
+ * 도메인 객체의 불변 조건(invariant)을 검증하기 위한 메서드들을 제공합니다.
+ * 도메인 객체의 검증을 위한 순수 유틸리티 클래스로, 스프링 빈으로 관리되지 않습니다.
+ * 모든 검증 실패 시 IllegalArgumentException을 발생시킵니다.
+ * </p>
+ *
+ * @author Kim Seung Won
+ * @since 2025-03-22
+ * @version 1.0
+ */
+object AssertionUtils {
+
+    /**
+     * 문자열이 null이거나 비어있지 않은지 검증합니다.
+     * @param string 검증할 문자열
+     * @param message 검증 실패 시 예외 메시지
+     * @throws IllegalArgumentException 문자열이 null이거나 공백일 경우
+     */
+    fun assertArgumentNotEmpty(
+        string: String?,
+        message: String
+    ) {
+        if (string.isNullOrBlank()) {
+            throw IllegalArgumentException(message) // TODO: 커스텀 예외로 교체 가능
+        }
+    }
+
+    /**
+     * 객체가 null이 아닌지 검증합니다.
+     * @param obj 검증할 객체
+     * @param message 검증 실패 시 예외 메시지
+     * @throws IllegalArgumentException 객체가 null일 경우
+     */
+    fun assertArgumentNotNull(
+        obj: Any?,
+        message: String
+    ) {
+        if (obj == null) {
+            throw IllegalArgumentException(message) // TODO: 커스텀 예외로 교체 가능
+        }
+    }
+
+    /**
+     * 숫자 값이 지정된 범위 내에 있는지 검증합니다.
+     * @param value 검증할 숫자 값
+     * @param minValue 허용 최소값 (포함)
+     * @param maxValue 허용 최대값 (포함)
+     * @param message 검증 실패 시 예외 메시지
+     * @throws IllegalArgumentException 값이 범위를 벗어날 경우
+     */
+    fun assertArgumentValueInRange(
+        value: Int,
+        minValue: Int,
+        maxValue: Int,
+        message: String
+    ) {
+        if (value < minValue || value > maxValue) {
+            throw IllegalArgumentException(message) // TODO: 예외 처리 개선 필요
+        }
+    }
+
+    /**
+     * 문자열 길이가 지정된 범위 내에 있는지 검증합니다.
+     * @param string 검증할 문자열
+     * @param minLength 허용 최소 길이 (포함)
+     * @param maxLength 허용 최대 길이 (포함)
+     * @param message 검증 실패 시 예외 메시지
+     * @throws IllegalArgumentException 문자열 길이가 범위를 벗어날 경우
+     */
+    fun assertArgumentLength(
+        string: String,
+        minLength: Int,
+        maxLength: Int,
+        message: String
+    ) {
+        if (string.length < minLength || string.length > maxLength) {
+            throw IllegalArgumentException(message) // TODO: 예외 처리 개선 필요
+        }
+    }
+
+    /**
+     * 문자열이 정규표현식과 일치하는지 검증합니다.
+     * @param string 검증할 문자열
+     * @param regex 검증에 사용할 정규표현식
+     * @param message 검증 실패 시 예외 메시지
+     * @throws IllegalArgumentException 문자열이 정규식과 일치하지 않을 경우
+     */
+    fun assertRegularExpression(
+        string: String,
+        regex: Regex,
+        message: String
+    ) {
+        if (!string.matches(regex)) {
+            throw IllegalArgumentException(message) // TODO: 예외 처리 개선 필요
+        }
+    }
+
+}

--- a/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/dto/user/UserInternalDTO.kt
+++ b/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/dto/user/UserInternalDTO.kt
@@ -1,0 +1,56 @@
+package com.dsm.hhh.internal.core.domain.model.dto.user
+
+import com.dsm.hhh.internal.core.domain.model.primitive.user.Birthday
+import com.dsm.hhh.internal.core.domain.model.primitive.user.BreakupDate
+import com.dsm.hhh.internal.core.domain.model.primitive.user.Email
+import com.dsm.hhh.internal.core.domain.model.primitive.user.EmotionStatus
+import com.dsm.hhh.internal.core.domain.model.primitive.user.HashedPassword
+import com.dsm.hhh.internal.core.domain.model.primitive.user.Name
+import com.dsm.hhh.internal.core.domain.model.primitive.user.Password
+import com.dsm.hhh.internal.core.domain.model.primitive.user.RegisteredAt
+import com.dsm.hhh.internal.core.domain.model.primitive.user.UserId
+
+/**
+ * UserInternalDTO - 계층별 데이터 변환을 위한 사용자 정보 도메인 데이터 클래스
+ * <p>
+ *
+ * @property id MongoDB에서 자동 생성되는 고유 식별자. 형식은 ObjectId
+ * @property email 사용자 이메일 주소 (unique 인덱스 적용)
+ * @property password 비밀번호
+ * @property name 사용자 실명
+ * @property birthday 사용자 생년월일
+ * @property breakupDate 마지막 이별일
+ * @property emotionStatus 사용자 가입일의 감정 상태 (단위: %).
+ * @property registeredAt 사용자 가입일
+ *
+ * <p>
+ *
+ * @author Kim Seung Won
+ * @since 2025-03-22
+ * @version 1.0
+ */
+data class UserInternalDTO(
+    val userId: UserId?,
+
+    val name: Name,
+    val email: Email,
+    val password: HashedPassword,
+
+    val birthday: Birthday,
+
+    val breakupDate: BreakupDate,
+    val emotionStatus: EmotionStatus,
+
+    val registeredAt: RegisteredAt?
+) {
+
+    constructor(
+        name: Name,
+        email: Email,
+        password: HashedPassword,
+        birthday: Birthday,
+        breakupDate: BreakupDate,
+        emotionStatus: EmotionStatus
+    ): this(null, name, email, password, birthday, breakupDate, emotionStatus, null)
+
+}

--- a/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/Birthday.kt
+++ b/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/Birthday.kt
@@ -1,0 +1,33 @@
+package com.dsm.hhh.internal.core.domain.model.primitive.user
+
+import com.dsm.hhh.internal.common.assertion.AssertionUtils
+import com.fasterxml.jackson.annotation.JsonValue
+
+/**
+ * Birthday - 생년월일 값 객체
+ * <p>
+ * 사용자의 생년월일을 표현하는 값 객체입니다.
+ * </p>
+ *
+ * @property birthday 생일 문자열 (YYYY-MM-DD 형식 예상)
+ *
+ * @author Kim Seung Won
+ * @since 2025-03-22
+ * @version 1.0
+ */
+@JvmInline
+value class Birthday(
+    private val birthday: String
+) {
+
+    init {
+        AssertionUtils.assertArgumentNotEmpty(birthday, "생일이 입력되지 않았습니다.")
+    }
+
+    /**
+     * 내부 값을 반환합니다.
+     * @return 생일 문자열
+     */
+    fun value() = birthday
+
+}

--- a/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/Birthday.kt
+++ b/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/Birthday.kt
@@ -1,7 +1,6 @@
 package com.dsm.hhh.internal.core.domain.model.primitive.user
 
 import com.dsm.hhh.internal.common.assertion.AssertionUtils
-import com.fasterxml.jackson.annotation.JsonValue
 
 /**
  * Birthday - 생년월일 값 객체

--- a/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/BreakupDate.kt
+++ b/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/BreakupDate.kt
@@ -1,7 +1,6 @@
 package com.dsm.hhh.internal.core.domain.model.primitive.user
 
 import com.dsm.hhh.internal.common.assertion.AssertionUtils
-import com.fasterxml.jackson.annotation.JsonValue
 
 /**
  * BreakupDate - 이별 일자 값 객체

--- a/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/BreakupDate.kt
+++ b/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/BreakupDate.kt
@@ -1,0 +1,33 @@
+package com.dsm.hhh.internal.core.domain.model.primitive.user
+
+import com.dsm.hhh.internal.common.assertion.AssertionUtils
+import com.fasterxml.jackson.annotation.JsonValue
+
+/**
+ * BreakupDate - 이별 일자 값 객체
+ * <p>
+ * 사용자의 마지막 이별 날짜를 표현하는 값 객체입니다.
+ * </p>
+ *
+ * @property breakupDate 이별 날짜 문자열 (YYYY-MM-DD 형식 예상)
+ *
+ * @author Kim Seung Won
+ * @since 2025-03-22
+ * @version 1.0
+ */
+@JvmInline
+value class BreakupDate(
+    private val breakupDate: String
+) {
+
+    init {
+        AssertionUtils.assertArgumentNotEmpty(breakupDate, "이별 날짜가 입력되지 않았습니다.")
+    }
+
+    /**
+     * 내부 값을 반환합니다.
+     * @return 이별 날짜 문자열
+     */
+    fun value() = breakupDate
+
+}

--- a/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/Email.kt
+++ b/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/Email.kt
@@ -1,0 +1,34 @@
+package com.dsm.hhh.internal.core.domain.model.primitive.user
+
+import com.dsm.hhh.internal.common.assertion.AssertionUtils
+import com.fasterxml.jackson.annotation.JsonValue
+
+/**
+ * Email - 사용자 이메일 주소 값 객체
+ * <p>
+ * 사용자 식별을 위한 이메일 주소를 표현하는 값 객체입니다.
+ * 시스템의 대체키로 사용됩니다.
+ * </p>
+ *
+ * @property email 이메일 주소
+ *
+ * @author Kim Seung Won
+ * @since 2025-03-22
+ * @version 1.0
+ */
+@JvmInline
+value class Email(
+    private val email: String
+) {
+
+    init {
+        AssertionUtils.assertArgumentNotEmpty(email, "이메일이 입력되지 않았습니다.")
+    }
+
+    /**
+     * 내부 값을 반환합니다.
+     * @return 이메일 주소 문자열
+     */
+    fun value() = email
+
+}

--- a/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/Email.kt
+++ b/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/Email.kt
@@ -1,7 +1,6 @@
 package com.dsm.hhh.internal.core.domain.model.primitive.user
 
 import com.dsm.hhh.internal.common.assertion.AssertionUtils
-import com.fasterxml.jackson.annotation.JsonValue
 
 /**
  * Email - 사용자 이메일 주소 값 객체

--- a/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/EmotionStatus.kt
+++ b/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/EmotionStatus.kt
@@ -1,0 +1,34 @@
+package com.dsm.hhh.internal.core.domain.model.primitive.user
+
+import com.dsm.hhh.internal.common.assertion.AssertionUtils
+import com.fasterxml.jackson.annotation.JsonValue
+
+/**
+ * EmotionStatus - 사용자 감정 상태 값 객체
+ * <p>
+ * 사용자의 현재 감정 상태를 0~100 범위로 표현하는 값 객체입니다.
+ * </p>
+ *
+ * @property emotionStatus 감정 상태 값 (0~100)
+ *
+ * @author Kim Seung Won
+ * @since 2025-03-22
+ * @version 1.0
+ */
+@JvmInline
+value class EmotionStatus(
+    private val emotionStatus: Int
+) {
+
+    init {
+        AssertionUtils.assertArgumentNotNull(emotionStatus, "현재 감정이 입력되지 않았습니다.")
+        AssertionUtils.assertArgumentValueInRange(emotionStatus, 0, 100, "현재 감정은 0 ~ 100로 입력해주세요.")
+    }
+
+    /**
+     * 내부 값을 반환합니다.
+     * @return 감정 상태 정수 값
+     */
+    fun value() = emotionStatus
+
+}

--- a/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/EmotionStatus.kt
+++ b/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/EmotionStatus.kt
@@ -1,7 +1,6 @@
 package com.dsm.hhh.internal.core.domain.model.primitive.user
 
 import com.dsm.hhh.internal.common.assertion.AssertionUtils
-import com.fasterxml.jackson.annotation.JsonValue
 
 /**
  * EmotionStatus - 사용자 감정 상태 값 객체

--- a/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/HashedPassword.kt
+++ b/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/HashedPassword.kt
@@ -1,0 +1,40 @@
+package com.dsm.hhh.internal.core.domain.model.primitive.user
+
+import com.dsm.hhh.external.security.PasswordEncoderUtils
+import com.dsm.hhh.internal.common.assertion.AssertionUtils
+
+/**
+ * HashedPassword - 해시 처리된 비밀번호 값 객체
+ * <p>
+ * 안전한 저장을 위해 해시 처리된 비밀번호를 표현하는 값 객체입니다.
+ * 원본 비밀번호와 달리 복잡도 검증은 수행하지 않습니다.
+ * </p>
+ *
+ * @property hashedPassword 해시된 비밀번호 문자열
+ *
+ * @author Kim Seung Won
+ * @since 2025-03-22
+ * @version 1.0
+ */
+@JvmInline
+value class HashedPassword(
+    private val hashedPassword: String
+) {
+
+    init {
+        AssertionUtils.assertArgumentNotEmpty(hashedPassword, "비밀번호가 입력되지 않았습니다.")
+    }
+
+    companion object {
+        fun fromPassword(password: Password): HashedPassword {
+            return HashedPassword(PasswordEncoderUtils.encode(password.value()))
+        }
+    }
+
+    /**
+     * 내부 값을 반환합니다.
+     * @return 해시된 비밀번호 문자열
+     */
+    fun value() = hashedPassword
+
+}

--- a/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/Name.kt
+++ b/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/Name.kt
@@ -1,7 +1,6 @@
 package com.dsm.hhh.internal.core.domain.model.primitive.user
 
 import com.dsm.hhh.internal.common.assertion.AssertionUtils
-import com.fasterxml.jackson.annotation.JsonValue
 
 /**
  * Name - 사용자 실명 값 객체

--- a/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/Name.kt
+++ b/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/Name.kt
@@ -1,0 +1,33 @@
+package com.dsm.hhh.internal.core.domain.model.primitive.user
+
+import com.dsm.hhh.internal.common.assertion.AssertionUtils
+import com.fasterxml.jackson.annotation.JsonValue
+
+/**
+ * Name - 사용자 실명 값 객체
+ * <p>
+ * 사용자의 실명을 표현하는 값 객체로, 비어있지 않음을 보장합니다.
+ * </p>
+ *
+ * @property name 사용자 실명
+ *
+ * @author Kim Seung Won
+ * @since 2025-03-22
+ * @version 1.0
+ */
+@JvmInline
+value class Name(
+    private val name: String
+) {
+
+    init {
+        AssertionUtils.assertArgumentNotEmpty(name, "이름이 입력되지 않았습니다.")
+    }
+
+    /**
+     * 내부 값을 반환합니다.
+     * @return 사용자 이름 문자열
+     */
+    fun value() = name
+
+}

--- a/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/Password.kt
+++ b/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/Password.kt
@@ -1,7 +1,6 @@
 package com.dsm.hhh.internal.core.domain.model.primitive.user
 
 import com.dsm.hhh.internal.common.assertion.AssertionUtils
-import com.fasterxml.jackson.annotation.JsonValue
 
 /**
  * Password - 사용자 비밀번호 값 객체

--- a/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/Password.kt
+++ b/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/Password.kt
@@ -1,0 +1,49 @@
+package com.dsm.hhh.internal.core.domain.model.primitive.user
+
+import com.dsm.hhh.internal.common.assertion.AssertionUtils
+import com.fasterxml.jackson.annotation.JsonValue
+
+/**
+ * Password - 사용자 비밀번호 값 객체
+ * <p>
+ * 비밀번호 복잡도 요구사항을 검증하는 값 객체입니다.
+ * 다음 규칙을 검증합니다:
+ * - 8~20자 길이
+ * - 영문, 숫자, 특수문자 포함
+ * - 공백 불허
+ * </p>
+ *
+ * @property password 원본 비밀번호 문자열
+ *
+ * @author Kim Seung Won
+ * @since 2025-03-22
+ * @version 1.0
+ */
+@JvmInline
+value class Password(
+    private val password: String
+) {
+
+    companion object {
+        val letterRegex = ".*[A-Za-z].*".toRegex()
+        val digitRegex = ".*\\d.*".toRegex()
+        val specialCharRegex = ".*[!@#\$%^&*()\\-+=].*".toRegex()
+        val spaceRegex = ".*\\s.*".toRegex()
+    }
+
+    init {
+        AssertionUtils.assertArgumentNotEmpty(password, "비밀번호가 입력되지 않았습니다.")
+        AssertionUtils.assertArgumentLength(password, 8, 20, "비밀번호는 8자 이상 20자 이하로 입력해야 합니다.")
+        AssertionUtils.assertRegularExpression(password, letterRegex, "비밀번호에는 최소 1개의 영문자가 포함되어야 합니다.")
+        AssertionUtils.assertRegularExpression(password, digitRegex, "비밀번호에는 최소 1개의 숫자가 포함되어야 합니다.")
+        AssertionUtils.assertRegularExpression(password, specialCharRegex, "비밀번호에는 최소 1개의 특수문자 (!@#\$%^&*()-+=)가 포함되어야 합니다.")
+        AssertionUtils.assertRegularExpression(password, spaceRegex, "비밀번호에는 공백을 포함할 수 없습니다.")
+    }
+
+    /**
+     * 내부 값을 반환합니다.
+     * @return 비밀번호 문자열
+     */
+    fun value() = password
+
+}

--- a/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/RegisteredAt.kt
+++ b/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/RegisteredAt.kt
@@ -1,7 +1,6 @@
 package com.dsm.hhh.internal.core.domain.model.primitive.user
 
 import com.dsm.hhh.internal.common.assertion.AssertionUtils
-import com.fasterxml.jackson.annotation.JsonValue
 import java.time.LocalDateTime
 
 /**

--- a/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/RegisteredAt.kt
+++ b/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/RegisteredAt.kt
@@ -1,0 +1,36 @@
+package com.dsm.hhh.internal.core.domain.model.primitive.user
+
+import com.dsm.hhh.internal.common.assertion.AssertionUtils
+import com.fasterxml.jackson.annotation.JsonValue
+import java.time.LocalDateTime
+
+/**
+ * RegisteredAt - 사용자 가입 일시 값 객체
+ * <p>
+ * 사용자 가입 일시를 명시적으로 표현하기 위한 값 객체입니다.
+ * @JsonValue 어노테이션으로 직렬화 시 ISO-8601 형식 문자열로 변환됩니다.
+ * </p>
+ *
+ * @property registeredAt 가입 일시 (LocalDateTime)
+ *
+ * @author Kim Seung Won
+ * @since 2025-03-22
+ * @version 1.0
+ */
+@JvmInline
+value class RegisteredAt(
+    private val registeredAt: LocalDateTime
+) {
+
+
+    init {
+        AssertionUtils.assertArgumentNotNull(registeredAt, "가입 날짜가 입력되지 않았습니다.")
+    }
+
+    /**
+     * 내부 값을 반환합니다.
+     * @return 가입 일시 객체
+     */
+    fun value() = registeredAt
+
+}

--- a/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/UserId.kt
+++ b/src/main/kotlin/com/dsm/hhh/internal/core/domain/model/primitive/user/UserId.kt
@@ -1,0 +1,33 @@
+package com.dsm.hhh.internal.core.domain.model.primitive.user
+
+import com.dsm.hhh.internal.common.assertion.AssertionUtils
+
+/**
+ * UserId - 사용자 식별자 값 객체
+ * <p>
+ * 시스템 내에서 사용자를 고유하게 식별하는 ID를 타입 안전하게 다루기 위한 값 객체입니다.
+ * @JsonValue 어노테이션으로 직렬화 시 문자열 값으로 변환됩니다.
+ * </p>
+ *
+ * @property userId 사용자 고유 식별자 (ObjectId)
+ *
+ * @author Kim Seung Won
+ * @since 2025-03-22
+ * @version 1.0
+ */
+@JvmInline
+value class UserId(
+    private val userId: String
+) {
+
+    init {
+        AssertionUtils.assertArgumentNotEmpty(userId, "유저 아이디가 입력되지 않았습니다.")
+    }
+
+    /**
+     * 내부 값을 반환합니다.
+     * @return 사용자 ID 문자열
+     */
+    fun value() = userId
+
+}

--- a/src/main/kotlin/com/dsm/hhh/internal/core/domain/service/user/UserRegisterService.kt
+++ b/src/main/kotlin/com/dsm/hhh/internal/core/domain/service/user/UserRegisterService.kt
@@ -1,0 +1,43 @@
+package com.dsm.hhh.internal.core.domain.service.user
+
+import com.dsm.hhh.internal.core.domain.model.dto.user.UserInternalDTO
+import com.dsm.hhh.internal.core.usecase.UserRegisterUseCase
+import com.dsm.hhh.internal.data.repository.user.UserRepository
+import com.mongodb.MongoTimeoutException
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Service
+import reactor.core.publisher.Mono
+
+/**
+ * UserRegisterService - 사용자 등록 서비스 구현체
+ * <p>
+ * 사용자 등록 비즈니스 로직을 처리하는 서비스 클래스입니다.
+ * UserRepository를 사용하여 데이터를 저장하고 예외 처리를 수행합니다.
+ * </p>
+ *
+ * @author Kim Seung Won
+ * @since 2025-03-22
+ * @version 1.0
+ */
+@Service
+private class UserRegisterService(
+    val userRepository: UserRepository
+): UserRegisterUseCase {
+
+    /**
+     * 사용자 정보를 등록합니다.
+     * 저장 과정에서 발생할 수 있는 예외를 처리합니다.
+     */
+    override fun register(userInternalDTO: UserInternalDTO): Mono<Void> {
+        return userRepository.save(userInternalDTO)
+            .onErrorResume { // TODO: 예외 개선 필요
+                when(it) {
+                    is DuplicateKeyException -> throw IllegalArgumentException("이미 가입된 이메일입니다.") // 409
+                    is MongoTimeoutException -> throw RuntimeException("MongoDB 연결에 문제가 생겼습니다.") // 500
+                    else -> throw RuntimeException("알 수 없는 오류 발생") // 500
+                }
+            }
+            .then()
+    }
+
+}

--- a/src/main/kotlin/com/dsm/hhh/internal/core/usecase/UserRegisterUseCase.kt
+++ b/src/main/kotlin/com/dsm/hhh/internal/core/usecase/UserRegisterUseCase.kt
@@ -1,0 +1,25 @@
+package com.dsm.hhh.internal.core.usecase
+
+import com.dsm.hhh.internal.core.domain.model.dto.user.UserInternalDTO
+import reactor.core.publisher.Mono
+
+/**
+ * UserRegisterUseCase - 사용자 등록 유스케이스 인터페이스
+ * <p>
+ * 사용자 등록 비즈니스 로직을 정의한 함수형 인터페이스입니다.
+ * </p>
+ *
+ * @author Kim Seung Won
+ * @since 2025-03-22
+ * @version 1.0
+ */
+fun interface UserRegisterUseCase {
+
+    /**
+     * 사용자 정보를 등록합니다.
+     * @param userInternalDTO 등록할 사용자 정보 DTO
+     * @return 처리 결과를 나타내는 Mono<Void>
+     */
+    fun register(userInternalDTO: UserInternalDTO): Mono<Void>
+
+}

--- a/src/main/kotlin/com/dsm/hhh/internal/data/repository/user/UserEntity.kt
+++ b/src/main/kotlin/com/dsm/hhh/internal/data/repository/user/UserEntity.kt
@@ -1,0 +1,57 @@
+package com.dsm.hhh.internal.data.repository.user
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import org.springframework.data.mongodb.core.mapping.Field
+import org.springframework.data.mongodb.core.mapping.FieldType
+import java.time.LocalDateTime
+
+/**
+ * UserEntity - Spring Data MongoDB에 의해 영속화되는 사용자 정보 도메인 데이터 클래스
+ * <p>
+ *
+ * @property id MongoDB에서 자동 생성되는 고유 식별자. 형식은 ObjectId (Insert 시 null 허용)
+ * @property email 사용자 이메일 주소 (unique 인덱스 적용)
+ * @property password 해시 처리된 비밀번호
+ * @property name 사용자 실명
+ * @property birthday 사용자 생년월일
+ * @property breakupDate 마지막 이별일
+ * @property emotionStatus 사용자 가입일의 감정 상태 (단위: %).
+ * @property registeredAt 사용자 가입일
+ *
+ * <p>
+ *
+ * @author Kim Seung Won
+ * @since 2025-03-22
+ * @version 1.0
+ */
+@Document(collection = "user-collection") // TODO: 현재 하드 코딩이지만, 추후 개선 예정
+class UserEntity private constructor(
+    @Id
+    val id: String?,
+
+    val name: String,
+    @Indexed(unique = true)
+    val email: String,
+    val password: String,
+
+    val birthday: String, // TODO: String으로 저장한 건지 Date 형식으로 저장할 건지 고민.
+
+    val breakupDate: String,
+    val emotionStatus: Int, // TODO: 사용자에게 입력 받은 현재의 감정 상태를 어떻게 저장하고 갱신할지 고민.
+
+    @Field(targetType = FieldType.DATE_TIME)
+    val registeredAt: LocalDateTime = LocalDateTime.now()
+) {
+
+    constructor(
+        name: String,
+        email: String,
+        password: String,
+        birthday: String,
+        breakupDate: String,
+        emotionStatus: Int
+    ) : this(null, name, email, password, birthday, breakupDate, emotionStatus)
+
+}

--- a/src/main/kotlin/com/dsm/hhh/internal/data/repository/user/UserMongoRepository.kt
+++ b/src/main/kotlin/com/dsm/hhh/internal/data/repository/user/UserMongoRepository.kt
@@ -1,0 +1,16 @@
+package com.dsm.hhh.internal.data.repository.user
+
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository
+
+/**
+ * UserMongoRepository - Spring Data MongoDB Reactive Repository
+ * <p>
+ * MongoDB와의 반응형(Reactive) 연동을 제공하는 Spring Data 인터페이스
+ * 기본 CRUD 연산을 지원하며 UserEntity를 관리합니다.
+ * </p>
+ *
+ * @author Kim Seung Won
+ * @since 2025-03-22
+ * @version 1.0
+ */
+interface UserMongoRepository: ReactiveMongoRepository<UserEntity, String>

--- a/src/main/kotlin/com/dsm/hhh/internal/data/repository/user/UserRepository.kt
+++ b/src/main/kotlin/com/dsm/hhh/internal/data/repository/user/UserRepository.kt
@@ -1,0 +1,25 @@
+package com.dsm.hhh.internal.data.repository.user
+
+import com.dsm.hhh.internal.core.domain.model.dto.user.UserInternalDTO
+import reactor.core.publisher.Mono
+
+/**
+ * UserRepository - 사용자 도메인 리포지토리 인터페이스
+ * <p>
+ * 도메인 계층에서 사용할 사용자 관련 데이터 접근 기능을 정의합니다.
+ * 구현체에서 실제 데이터 저장소 연동을 처리합니다.
+ * </p>
+ *
+ * @author Kim Seung Won
+ * @since 2025-03-22
+ * @version 1.0
+ */
+interface UserRepository {
+
+    /**
+     * 사용자 정보를 저장합니다.
+     * @param userInternalDTO 저장할 사용자 DTO
+     * @return 저장된 사용자 정보를 담은 Mono
+     */
+    fun save(userInternalDTO: UserInternalDTO): Mono<UserInternalDTO>
+}

--- a/src/main/kotlin/com/dsm/hhh/internal/data/repository/user/UserRepositoryImpl.kt
+++ b/src/main/kotlin/com/dsm/hhh/internal/data/repository/user/UserRepositoryImpl.kt
@@ -1,0 +1,29 @@
+package com.dsm.hhh.internal.data.repository.user
+
+import com.dsm.hhh.internal.core.domain.model.dto.user.UserInternalDTO
+import com.dsm.hhh.internal.data.repository.user.mapper.UserEntityMapper
+import org.springframework.stereotype.Repository
+import reactor.core.publisher.Mono
+
+/**
+ * UserRegisterUseCase - 사용자 회원가입 요청 양식
+ * <p>
+ *
+ * <p>
+ *
+ * @author Kim Seung Won
+ * @since 2025-03-22
+ * @version 1.0
+ */
+@Repository
+class UserRepositoryImpl(
+    val userMongoRepository: UserMongoRepository
+): UserRepository {
+
+    override fun save(userInternalDTO: UserInternalDTO): Mono<UserInternalDTO> {
+        val userEntity = UserEntityMapper.toEntity(userInternalDTO)
+        return userMongoRepository.save(userEntity)
+            .map { UserEntityMapper.toDTO(it) };
+    }
+
+}

--- a/src/main/kotlin/com/dsm/hhh/internal/data/repository/user/mapper/UserEntityMapper.kt
+++ b/src/main/kotlin/com/dsm/hhh/internal/data/repository/user/mapper/UserEntityMapper.kt
@@ -1,0 +1,65 @@
+package com.dsm.hhh.internal.data.repository.user.mapper
+
+import com.dsm.hhh.internal.core.domain.model.dto.user.UserInternalDTO
+import com.dsm.hhh.internal.core.domain.model.primitive.user.Birthday
+import com.dsm.hhh.internal.core.domain.model.primitive.user.BreakupDate
+import com.dsm.hhh.internal.core.domain.model.primitive.user.Email
+import com.dsm.hhh.internal.core.domain.model.primitive.user.EmotionStatus
+import com.dsm.hhh.internal.core.domain.model.primitive.user.HashedPassword
+import com.dsm.hhh.internal.core.domain.model.primitive.user.Name
+import com.dsm.hhh.internal.core.domain.model.primitive.user.RegisteredAt
+import com.dsm.hhh.internal.core.domain.model.primitive.user.UserId
+import com.dsm.hhh.internal.data.repository.user.UserEntity
+
+/**
+ * UserEntityMapper - DTO와 엔티티 변환 매퍼
+ * <p>
+ * UserInternalDTO와 UserEntity 간의 변환을 담당하는 매퍼 클래스입니다.
+ * 컴패니언 객체로 구현되어 인스턴스 생성 없이 사용 가능합니다.
+ * </p>
+ *
+ * @author Kim Seung Won
+ * @since 2025-03-22
+ * @version 1.0
+ */
+class UserEntityMapper {
+
+    companion object {
+
+        /**
+         * DTO를 엔티티로 변환합니다.
+         * @param userInternalDTO 변환할 DTO 객체
+         * @return 변환된 UserEntity 객체
+         */
+        fun toEntity(userInternalDTO: UserInternalDTO): UserEntity {
+            return UserEntity(
+                name = userInternalDTO.name.value(),
+                email = userInternalDTO.email.value(),
+                password = userInternalDTO.password.value(),
+                birthday = userInternalDTO.birthday.value(),
+                breakupDate = userInternalDTO.breakupDate.value(),
+                emotionStatus = userInternalDTO.emotionStatus.value()
+            )
+        }
+
+        /**
+         * 엔티티를 DTO로 변환합니다.
+         * @param userEntity 변환할 엔티티 객체
+         * @return 변환된 UserInternalDTO 객체
+         */
+        fun toDTO(userEntity: UserEntity): UserInternalDTO {
+            return UserInternalDTO(
+                userId = UserId(userEntity.id!!),
+                name = Name(userEntity.name),
+                email = Email(userEntity.email),
+                password = HashedPassword(userEntity.password),
+                birthday = Birthday(userEntity.birthday),
+                breakupDate = BreakupDate(userEntity.breakupDate),
+                emotionStatus = EmotionStatus(userEntity.emotionStatus),
+                registeredAt = RegisteredAt(userEntity.registeredAt)
+            )
+        }
+
+    }
+
+}


### PR DESCRIPTION
## 📌 PR 요약
- UserRegister 기능 추가와 관련된 작업을 포함하여, 데이터 접근 계층, 보안 유틸리티, 공통 유틸리티, 도메인 객체 등을 구현하였습니다.

---

## 📋 작업 내용
- [x] UserRegister 기능 추가
- [x] User DAO 관련 클래스 추가
- [x] PasswordEncoderUtils 구현
- [x] AssertionUtils 구현
- [x] Domain Primitive Object 구현

---

## 🔍 체크리스트
- [x] 코드가 예상대로 작동하는지 확인했습니다.
- [x] 문서화를 완료했습니다 (API 명세서, Readme 등).

---

## 📝 기타 참고 사항
- PasswordEncoder를 Spring Bean으로 관리하지 않는 이유는 Notion의 관련 문서를 참고해주세요.
- Domain Primitive 관련 내용은 Notion의 `Domain Primitive가 팀 컨벤션까지 확장된 이유 및 근거 정리` 문서를 참고해주세요.